### PR TITLE
Add TCPRoute

### DIFF
--- a/traffic-specs.md
+++ b/traffic-specs.md
@@ -77,6 +77,18 @@ important differences. In particular, *all* filters must match whereas `matches`
 simply define what the traffic *could* look like. Individual matches are used
 regularly with TrafficTargets (see the `/metrics` example above).
 
+### TCPRoute
+
+This resource is used to describe L4 TCP traffic. It is a simple route which configures
+an application to receive raw non protocol specific traffic.
+
+```
+apiVersion: specs.smi-spec.io/v1alpha1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+```
+
 ## Automatic Generation
 
 While it is possible for users to create these by hand, the recommended pattern


### PR DESCRIPTION
Adding TCP routes for raw L4 traffic, this route has no rules and therefore when used with TrafficRole specs would be omitted.

```yaml
apiVersion: specs.smi-spec.io/v1alpha1
kind: TCPRoute
metadata:
  name: tcp-route

---
kind: TrafficRole
apiVersion: access.smi-spec.io/v1alpha1
metadata:
  name: path-specific
  namespace: default
resource:
  name: foo
  kind: Deployment
port: 8080
rules:
- kind: TCPRoute
  name: tcp-routes
```