### PR TITLE
Cluster traffic

### DIFF
--- a/traffic-specs.md
+++ b/traffic-specs.md
@@ -30,11 +30,6 @@ matches:
 - name: health
   pathRegex: "/ping"
   methods: ["*"]
-filters:
-- kind: Service
-  name: foobar
-  ports:
-  - 8080
 ```
 
 This example defines two matches, `metrics` and `health`. The name is the
@@ -47,7 +42,9 @@ These routes have not yet been associated with any resources. See
 associated with applications serving traffic.
 
 The `matches` field only applies to URIs. It is common to look at other parts of
-an HTTP request. This is where `filters` come in:
+an HTTP request. This behaviour is not yet defined; however, the spec will be
+extended at a later date to accommodate capabilities such as HTTP header, 
+Host, etc.
 
 ```yaml
 apiVersion: v1beta1
@@ -59,23 +56,9 @@ matches:
 - name: everything
   pathRegex: ".*"
   methods: ["*"]
-filters:
-- kind: Service
-  name: foobar
-  ports:
-  - 8080
 ```
 
-This example defines a single route that matches anything. It then describes a
-filter. This filter looks at the `Host` or `:authority` header and scopes the
-route matches to requests with the value
-`foobar.default.svc.cluster.local:8080`. This is the FQDN of the `foobar`
-service and port listed.
-
-At initial glance, filters and matches are pretty similar. There are some
-important differences. In particular, *all* filters must match whereas `matches`
-simply define what the traffic *could* look like. Individual matches are used
-regularly with TrafficTargets (see the `/metrics` example above).
+This example defines a single route that matches anything. 
 
 ### TCPRoute
 


### PR DESCRIPTION
## ClusterTrafficTarget
I have made a couple of changes to remove `ClusterTrafficTarget`, since `ClusterTrafficTarget` is a global object it could allow the modification of service traffic for a service which the user does not have control. For example:

Given a `ClusterTrafficTarget` which allows metrics access for all services which do not contain the protected label.
```yaml
kind: ClusterTrafficTarget
apiVersion: v1beta1
metadata:
  name: metrics-scrape
selector:
  matchExpressions:
  - !protected
port: 8080
specs:
- kind: HTTPRoutes
  name: the-routes
  namespace: prometheus
  matches:
  - metrics
```
This `ClusterTrafficTarget` is `global` it is not owned by a particular service and therefore it would be possible for a user who has global modification capabilities to modify the behavior of an asset they do not own.  For example, I could define a `TCPRoute` and then modify the `ClusterTrafficTarget`:

```yaml
apiVersion: specs.smi-spec.io/v1alpha1
kind: TCPRoute
metadata:
  name: tcp-route

kind: ClusterTrafficTarget
apiVersion: v1beta1
metadata:
  name: metrics-scrape
selector:
  matchExpressions:
  - protected
port: 8080
specs:
- kind: HTTPRoutes
  name: the-routes
  namespace: prometheus
  matches:
  - metrics
 - kind: TCPRoute
   name: tcp-route
   namespace: default
```

The result of the above change would allow all TCP traffic to protected services. The user submitting the `ClusterTrafficTarget` is changing the security behavior of service which they do not own and this should be strictly forbidden. While there is a possibility that this situation could arise from malicious behavior the likelihood is that it would be accidental. Where possible the spec should not provide a footgun for users. Only the owner of the service should be able to modify the security properties of that service.

I am also proposing that filters are removed from `RouteGroups` as I am not confident this is the correct hierarchy, it implies that `RouteGroups` are a parent of a `Service` and I think this is actually the other way round.

I think the core problem is that we need to reason correctly about access which is `Authenticated` and traffic which is `Authorized`, we also need to think higher level about the relation between Traffic Specs and the Services which own them. 
If an endpoint is `Authenticated` then to allow access to traffic the owner of the service should define the appropriate TrafficTarget to allow `Authorization` for Prometheus scrapers. It should not be possible to mix routes which contain `Authenticated` and `Unauthenticated`, this is mainly due to the physical listener of the port. A service will either listen using TLS and enforce mTLS for client authentication or it will not.

I don't think we should start this process until after KubeCon and we get some public feedback on what exists but in the future, I think that we should be looking at the following type of domain model.

```yaml
apiVersion: v1beta1
kind: HTTPRouteGroup
metadata:
  name: metrics
matches:
- name: metrics
  pathRegex: "/metrics"
  methods:
  - GET

apiVersion: v1beta1
kind: HTTPRouteGroup
metadata:
  name: api
matches:
- name: api
  pathRegex: "/api"
  methods:
  - GET
  - POST

# Secured listener with mTLS and deny all Authz unless overridden by TrafficTarget
apiVersion: specs.smi-spec.io/v1alpha1
kind: Listener
metadata:
  name: mTLS_listener
port: 8080
authenticated: true // secured by identity based mTLS connection
serviceRef:
  name: service-a
routes:
  - kind: HTTPRouteGroup
    name: api

# Unsecured listener for open traffic
apiVersion: specs.smi-spec.io/v1alpha1
kind: Listener
metadata:
  name: http_listener
port: 9125
authenticated: false // plain HTTP or HTTPS connection no authentication using mTLS
serviceRef:
  name: service-a
routes:
  - kind: HTTPRouteGroup
    name: metrics
```

While there is always an element of convenience with global modifiers I strongly believe we need to keep to a security model which defines that only the owner of a service is allowed to modify its ingress policy. There may be a small amount of extra administration for the individual service owner however this comes with the benefit of a security policy which is less prone to mistaken configuration and therefore more secure.