### PR TITLE
Add governance doc and CODEOWNERS for smi-spec

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+* @alban
+* @brendandburns
+* @gabrtv
+* @grampelberg
+* @lachie83
+* @leecalcote
+* @nicholasjackson
+* @slack
+* @stefanprodan
+* @surajssd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,31 @@
 # Contributing
 
 ## Support Channels
+
 Whether you are a user or contributor, official support channels include:
+
 - [Issues](https://github.com/deislabs/smi-spec/issues)
 - #general Slack channel in the [SMI Slack](https://smi-spec.slack.com)
 
 ## CLA Requirement
+
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
 ## Specifications subject to the Open Web Foundation Agreements.
+
 In addition, by making a contribution to specifications in this repository, you, on behalf of yourself, your employer, and its affiliates, are making those contributions subject to the obligations set forth in the [OWF Contributor License Agreement 1.0 - Copyright and Patent](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owf-contributor-license-agreement-1-0---copyright-and-patent).  
 Final specifications developed in this repository will be subject to the [Open Web Foundation Final Specification Agreement (“OWFa 1.0”)](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-00).  OWFa 1.0 will be applied as follows:
+
 -	The maintainer will notify all contributors to a designated specification in writing via provided contact information of the start of a 30 day review period, after which the specification will be subject to the OWFa 1.0.
 -	During that 30 day period, contributors may provide written notice to the maintainer that the contributor is not making the forgoing commitment under OWFa 1.0 for the designated specification (“Exclusion”).
 -	Upon the end of that 30 day notice period, those contributors who have not issued an Exclusion, on behalf of themselves, their employer, and its affiliates, will, without further action, be subject to the obligations set forth in the OWFa 1.0 for the designated specification.  
 
+## Project Governance
+
+Project maintainership is outlined in the [GOVERNANCE](GOVERNANCE.md) file.
+
 ## Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com (mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,13 @@
+# Governance
+
+## Project Maintainers
+
+[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating the SMI specification. Final decisions on the spec reside with the project maintainers.
+
+Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
+
+New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. A potential maintainer may be nominated by an existing maintainer. A vote is conducted in private between the current maintainers over the course of a one week voting period. At the end of the week, votes are counted and a pull request is made on the repo adding the new maintainer to the [CODEOWNERS](CODEOWNERS) file.
+
+A maintainer may step down by submitting an [issue](https://github.com/deislabs/smi-spec/issues/new) stating their intent.
+
+Changes to this governance document require a pull request with approval from a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the current maintainers.


### PR DESCRIPTION
This PR adds a document for governance and CODEOWNERS.

The initial list of owners was pulled from the contributor graph for smi-spec.

After this change is merged we will enable required review from two CODEOWNERS for subsequent merges to master.