### PR TITLE
Create 'Service' CRD to register and reference k8s and non-k8s compute resources

### DIFF
--- a/traffic-access-control.md
+++ b/traffic-access-control.md
@@ -73,6 +73,49 @@ sources:
 - kind: ServiceAccount
   name: prometheus
   namespace: default
+- kind: Service
+  name: foo.mesh
+- kind: Service
+  name: bar.mesh
+- kind: Service
+  name: baz.mesh
+```
+
+```yaml
+# Register a service 'foo.mesh'
+# The service is sesolvable by DNS
+apiVersion: specs.smi-spec.io/v1alpha1
+kind: Service
+metadata:
+  name: foo.mesh
+spec:
+  type: DNS
+```
+
+```yaml
+# Register a service already existing within the Kubernetes cluster
+apiVersion: specs.smi-spec.io/v1alpha1
+kind: Service
+metadata:
+  name: bar.mesh
+spec:
+  type: Kubernetes
+  cluster: aks-4d61b17c.hcp.westus2.azmk8s.io
+  locator: /namespace/default/service/bar
+```
+
+```yaml
+# Register a service consisting of a specific cloud vendor's component
+# Members of the service (IP addresses) are resolvable by querying the
+# particular cloud provider (type) for the given resource (locator)
+apiVersion: specs.smi-spec.io/v1alpha1
+kind: Service
+metadata:
+  name: baz.mesh
+spec:
+  type: Azure
+  locator: /resource/subscriptions/e3f0/resourceGroups/mesh-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz
+  port: 7654
 ```
 
 This example selects all the pods which have the `service-a` `ServiceAccount`.


### PR DESCRIPTION
The intent of this PR is to begin a discussion and propose the addition of a new CRD `Service`.

The purpose of the new `service.specs.smi-spec.io` is to register and uniquely identify a component (service) within a service mesh, which spans **multiple** Kubernetes clusters, and also includes **non-Kubernetes** compute resources. The *component* could be anything resolvable to a list of IP addresses and a port:
  - Kubernetes service
  - DNS record
  - Virtual Machines within a cloud provider

Once a service is registered, `foo.mesh` for instance, it will be referenced by `TrafficTarget` (example below), `TrafficSplit`, etc.

For each `type` of `Service`, the service mesh needs to implement a resolver.  The new CRD's duty is to provide sufficient and unambiguous information to the service mesh controller, so that it can obtain:
  - list of IP addresses for the given service
  - TLS certificate

The proposal is to augment the existing spec and add the optional ability to reference a `Service`, not replace references to `ServiceAccount`. For service meshes where a single Kubernetes cluster is involved - `kind: ServiceAccount` (illustrated in `TrafficTarget`) is sufficient.  For multiple Kubernetes clusters forming a mesh however, `ServiceAccount` is not specific enough - we need to identify the Kubernetes cluster and ideally also the Kubernetes service within that service account.

In the proposal below we deliberately skip the explicit indication of a `ServiceAccount`. Identity discovery for each registered service would be an implementation detail of the particular service mesh. In the case of `Service` with `type: Kubernetes`, there could be a 1:1 relationship between Kubernetes Service and ServiceAccount - the service mesh would expect the Service to belong to a ServiceAccount with the same name.

### Example
In the example below we register 3 unique services:
  - `foo.mesh`, which is resolvable via DNS
  - `bar.mesh`, which is a unique name alias of a Kubernetes Service on a uniquely identified Kubernetes cluster and the given name space
  -  `baz.mesh` - referencing a virtual machine scale set within a specific Azure subscription, along with a port

The `TrafficTarget` in this case declares that services `foo.mesh`, `bar.mesh`, and `baz.mesh` (as well as `prometheus`) are allowed to access `service-a` on port 8080 and at the given URL endpoints.

To show a simpler example:
```yaml
kind: TrafficTarget
apiVersion: access.smi-spec.io/v1alpha1
metadata:
  name: bar-to-baz
destination:
  kind: Service
  name: baz.mesh
specs:
- kind: HTTPRouteGroup
  name: the-routes
  matches:
  - metrics
sources:
- kind: Service
  name: bar.mesh
```

The policy above declares that `bar.mesh` can access `baz.mesh`.

To be more specific - the policy declares that `bar.mesh`, which is the pods forming Kubernetes Service `bar`, in the default namespace on Kubernetes cluster `aks-4d61b17c.hcp.westus2.azmk8s.io`, can access service `baz.mesh`, which is a virtual machine scale set on Azure uniquely identified by `/resource/subscriptions/e3f0/resourceGroups/mesh-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz`.

### Existing work
I see that @nicholasjackson is already working on something very similar (https://github.com/deislabs/smi-spec/pull/60) and would love to combine the 2 efforts.

### Note on the code changes
I don't intend on actually merging the specific proposed changes below. Once we have achieved consensus, I will augment this PR (or create a new one) with the actual CRD + documentation and examples. For the time being I am going to temporarily leverage the existing example of `TrafficTarget` for better illustration.

### Note on naming
Even though it is name-spaced under `specs.smi-spec.io`, the name `Service` may be confusing since it conflicts with the existing core Kubernetes resource. Looking forward to suggestions on better naming this CRD.