### PR TITLE
Adding links & clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,5 @@
 # Contributing
 
-## Support Channels
-
-Whether you are a user or contributor, official support channels include:
-
-- [Issues](https://github.com/deislabs/smi-spec/issues)
-- [#general](https://smi-spec.slack.com/archives/CJJF5M5NK) Slack channel in the
-[SMI Slack](https://smi-spec.slack.com)
-
 ## CLA Requirement
 
 This project welcomes contributions and suggestions. Most contributions require
@@ -49,11 +41,3 @@ OWFa 1.0 will be applied as follows:
 
 Project maintainership is outlined in the [GOVERNANCE](GOVERNANCE.md) file.
 
-## Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of
-conduct](https://opensource.microsoft.com/codeofconduct/). For more information
-see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-opencode@microsoft.com (mailto:opencode@microsoft.com) with any additional
-questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,3 @@ OWFa 1.0 will be applied as follows:
 ## Project Governance
 
 Project maintainership is outlined in the [GOVERNANCE](GOVERNANCE.md) file.
-

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ like +NetworkPolicy+, +Ingress+ and +CustomMetrics+.
 
 ### Community Meeting
 
-- Community Meeting: every other Wednesday at 9:30-10:30 Pacific: [https://zoom.us/j/448032371](https://zoom.us/j/448032371)
-  - [Calendar invite](https://calendar.google.com/calendar/embed?src=v2ailcfbvg9mgco5p0ms4t8ou8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-  - [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
+* Community Meeting: every other Wednesday at 9:30-10:30 Pacific: [https://zoom.us/j/448032371](https://zoom.us/j/448032371)
+  * [Calendar invite](https://calendar.google.com/calendar/embed?src=v2ailcfbvg9mgco5p0ms4t8ou8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+  * [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
 
 ### Slack
 
-- [SMI Slack](https://smi-spec.slack.com):
-  - [#general](https://smi-spec.slack.com/messages/general)
+* [SMI Slack](https://smi-spec.slack.com):
+  * [#general](https://smi-spec.slack.com/messages/general)
 
 [Sign up](https://aka.ms/smi/slack) for SMI Slack
 
@@ -86,7 +86,7 @@ contributing to the specification.
 
 Whether you are a user or contributor, you can open issues on GitHub:
 
-- [Issues](https://github.com/deislabs/smi-spec/issues)
+* [Issues](https://github.com/deislabs/smi-spec/issues)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,29 @@ like +NetworkPolicy+, +Ingress+ and +CustomMetrics+.
 
 ## Communications
 
-### Slack Channel
+### Community Meeting
 
-If you are not yet a member of the SMI Slack you may sign up
-[here](https://aka.ms/smi/slack).
+- Community Meeting: every other Wednesday at 9:30-10:30 Pacific: [https://zoom.us/j/448032371](https://zoom.us/j/448032371)
+  - [Calendar invite](https://calendar.google.com/calendar/embed?src=v2ailcfbvg9mgco5p0ms4t8ou8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+  - [Meeting notes](https://docs.google.com/document/d/1NTBaJf6LhUBlF8_lfvBBt_MbyPvT-6CZNg6Ckpm_yCo/edit?usp=sharing)
+
+### Slack
+
+- [SMI Slack](https://smi-spec.slack.com):
+  - [#general](https://smi-spec.slack.com/messages/general)
+
+[Sign up](https://aka.ms/smi/slack) for SMI Slack
 
 ## Contributing
 
 Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for more information on
 contributing to the specification.
+
+## Support
+
+Whether you are a user or contributor, you can open issues on GitHub:
+
+- [Issues](https://github.com/deislabs/smi-spec/issues)
 
 ## License
 
@@ -80,3 +94,12 @@ The specification is licensed under [OWF Contributor License Agreement 1.0 -
 Copyright and
 Patent](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owf-contributor-license-agreement-1-0---copyright-and-patent)
 in the [LICENSE](./LICENSE) file.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of
+conduct](https://opensource.microsoft.com/codeofconduct/). For more information
+see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+opencode@microsoft.com (mailto:opencode@microsoft.com) with any additional
+questions or comments.


### PR DESCRIPTION
In this PR I am...
- adding information to help people join the community meeting (zoom link, google doc with meeting minutes, calendar invite)
- clarifying that the code of conduct applies to all participation by moving it to the README
- directing support requests solely to GitHub issues (as we don't have a clear process to turn requests that are brought up in Slack into trackable issues)
- making it clearer how to join the discussions in Slack

While this edits the README it does not address all points in https://github.com/deislabs/smi-spec/issues/106. It does, however, fully resolve https://github.com/deislabs/smi-spec/issues/84 if merged as-is.