### PR TITLE
Cleanup CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alban @brendandburns @gabrtv @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @surajssd @michelleN
+* @grampelberg @lachie83 @leecalcote @nicholasjackson @slack @stefanprodan @michelleN @bridgetkromhout


### PR DESCRIPTION
This PR updates the list of CODEOWNERS based on the verbiage found [here](https://github.com/deislabs/smi-spec/blob/master/GOVERNANCE.md#project-maintainers).

Specifically it removes as they haven't been active on the specification for the last 3 months:
* @alban 
* @brendandburns 
* @gabrtv 
* @surajssd 

And adds:
* @bridgetkromhout

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>